### PR TITLE
feat: Add caching for the docker image to “improve” build time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Cache Docker Image
+      - name: Restore Cached Docker Image
+        run: |
+          if (Test-Path "C:\docker-cache\image.tar") {
+            docker load -i C:\docker-cache\image.tar
+          }
+        shell: powershell
+
+      - name: Pull UnityCI Docker Image
+        run: |
+          docker pull unityci/editor:windows-6000.0.43f1-windows-il2cpp-3
+          mkdir -Force C:\docker-cache
+          docker save unityci/editor:windows-6000.0.43f1-windows-il2cpp-3 -o C:\docker-cache\image.tar
+        shell: powershell
+
+      - name: Cache Docker Image
+        uses: actions/cache@v4
+        with:
+          path: C:\docker-cache\image.tar
+          key: docker-windows-unityci-${{ github.sha }}
+          restore-keys: |
+            docker-windows-unityci-
+
       # Cache Unity Library
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Build Project
 
 on: 
   push:
-    branches: [ "main" , "workflow" ]
+    branches: [ "main", "workflow" ]
   workflow_dispatch:
 
 jobs:
@@ -10,21 +10,27 @@ jobs:
     name: Build App
     runs-on: windows-latest
     steps:
-      # Checkout
+      # Checkout repository
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Cache
-      - uses: actions/cache@v3
+      # Cache Unity Library
+      - uses: actions/cache@v4
         with:
           path: Library
-          key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          key: Library-${{ runner.os }}-${{ hashFiles('Packages/manifest.json', 'ProjectSettings/ProjectVersion.txt') }}
           restore-keys: |
-            Library-
+            Library-${{ runner.os }}-
 
-      - name: Create Unity Cache Directory
-        run: |
-          mkdir -p C:/Users/ContainerAdministrator/AppData/Local/Unity/Caches
+      # Cache Unity Cache Files
+      - uses: actions/cache@v4
+        with:
+          path: C:/Users/ContainerAdministrator/AppData/Local/Unity/Caches
+          key: unity-cache-${{ runner.os }}
+
+      # Cache Unity installation to avoid reinstalling
+      - name: Cache Unity
+        uses: game-ci/unity-cache@v2
 
       # Build
       - name: Build App
@@ -37,9 +43,17 @@ jobs:
           targetPlatform: StandaloneWindows64
           buildName: ChuniXR
           buildsPath: exported
+          verbosity: minimal  # Reduce logging for faster execution
 
-      # Upload exported Android Studio project
+      # Cache built project to avoid re-uploading unchanged builds
+      - uses: actions/cache@v4
+        with:
+          path: exported
+          key: build-output-${{ github.sha }}
+
+      # Upload exported build
       - uses: actions/upload-artifact@v4
         with:
           name: Exported
           path: exported
+          compression-level: 0  # Faster uploads

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:\docker-cache\image.tar
-          key: docker-windows-unityci-${{ github.sha }}
+          key: docker-windows-unityci
           restore-keys: |
-            docker-windows-unityci-
+            docker-windows-unityci
 
       # Restore Cached Docker Image
       - name: Restore Cached Docker Image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,16 @@ jobs:
           }
         shell: powershell
 
+      # Pull UnityCI Docker Image if not cached
+      - name: Pull UnityCI Docker Image
+        run: |
+          if (-not (Test-Path "C:\docker-cache\image.tar")) {
+            docker pull unityci/editor:windows-6000.0.43f1-windows-il2cpp-3
+            mkdir -Force C:\docker-cache
+            docker save unityci/editor:windows-6000.0.43f1-windows-il2cpp-3 -o C:\docker-cache\image.tar
+          }
+        shell: powershell
+
       # Cache Unity Library
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,6 @@ jobs:
           path: C:/Users/ContainerAdministrator/AppData/Local/Unity/Caches
           key: unity-cache-${{ runner.os }}
 
-      # Cache Unity installation to avoid reinstalling
-      - name: Cache Unity
-        uses: game-ci/unity-cache@v2
-
       # Build
       - name: Build App
         uses: game-ci/unity-builder@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,16 +31,6 @@ jobs:
           }
         shell: powershell
 
-      # Pull UnityCI Docker Image if not cached
-      - name: Pull UnityCI Docker Image
-        run: |
-          if (-not (Test-Path "C:\docker-cache\image.tar")) {
-            docker pull unityci/editor:windows-6000.0.43f1-windows-il2cpp-3
-            mkdir -Force C:\docker-cache
-            docker save unityci/editor:windows-6000.0.43f1-windows-il2cpp-3 -o C:\docker-cache\image.tar
-          }
-        shell: powershell
-
       # Cache Unity Library
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,12 +22,6 @@ jobs:
           restore-keys: |
             Library-${{ runner.os }}-
 
-      # Cache Unity Cache Files
-      - uses: actions/cache@v4
-        with:
-          path: C:/Users/ContainerAdministrator/AppData/Local/Unity/Caches
-          key: unity-cache-${{ runner.os }}
-
       # Build
       - name: Build App
         uses: game-ci/unity-builder@v4
@@ -39,7 +33,6 @@ jobs:
           targetPlatform: StandaloneWindows64
           buildName: ChuniXR
           buildsPath: exported
-          verbosity: minimal  # Reduce logging for faster execution
 
       # Cache built project to avoid re-uploading unchanged builds
       - uses: actions/cache@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,21 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Cache Docker Image
-      - name: Restore Cached Docker Image
-        run: |
-          if (Test-Path "C:\docker-cache\image.tar") {
-            docker load -i C:\docker-cache\image.tar
-          }
-        shell: powershell
-
-      - name: Pull UnityCI Docker Image
-        run: |
-          docker pull unityci/editor:windows-6000.0.43f1-windows-il2cpp-3
-          mkdir -Force C:\docker-cache
-          docker save unityci/editor:windows-6000.0.43f1-windows-il2cpp-3 -o C:\docker-cache\image.tar
-        shell: powershell
-
+      # Cache Docker Image (Restoration before checking)
       - name: Cache Docker Image
         uses: actions/cache@v4
         with:
@@ -36,6 +22,24 @@ jobs:
           key: docker-windows-unityci-${{ github.sha }}
           restore-keys: |
             docker-windows-unityci-
+
+      # Restore Cached Docker Image
+      - name: Restore Cached Docker Image
+        run: |
+          if (Test-Path "C:\docker-cache\image.tar") {
+            docker load -i C:\docker-cache\image.tar
+          }
+        shell: powershell
+
+      # Pull UnityCI Docker Image if not cached
+      - name: Pull UnityCI Docker Image
+        run: |
+          if (-not (Test-Path "C:\docker-cache\image.tar")) {
+            docker pull unityci/editor:windows-6000.0.43f1-windows-il2cpp-3
+            mkdir -Force C:\docker-cache
+            docker save unityci/editor:windows-6000.0.43f1-windows-il2cpp-3 -o C:\docker-cache\image.tar
+          }
+        shell: powershell
 
       # Cache Unity Library
       - uses: actions/cache@v4


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 提供的总结

在构建工作流程中，为 Unity Library 和 UnityCI Docker 镜像实现了缓存，以减少构建时间。 同时缓存构建的项目，以避免重新上传未更改的构建。

CI:
- 为 Unity Library 添加缓存以减少构建时间。
- 为 UnityCI Docker 镜像添加缓存以减少构建时间。
- 缓存构建的项目以避免重新上传未更改的构建。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implements caching for the Unity Library and the UnityCI Docker image in the build workflow to reduce build times. Also caches the built project to avoid re-uploading unchanged builds.

CI:
- Adds caching for the Unity Library to reduce build times.
- Adds caching for the UnityCI Docker image to reduce build times.
- Caches the built project to avoid re-uploading unchanged builds.

</details>